### PR TITLE
Adding Game Number into Image Name that Downloaded

### DIFF
--- a/components/StatsModal.tsx
+++ b/components/StatsModal.tsx
@@ -211,11 +211,12 @@ export default function StatsModal(props: Props) {
 
     const dataURL = canvas.toDataURL();
     const blob = await (await fetch(dataURL)).blob();
-
+    const imageName = `katla-${game.num}.jpg`;
+    
     if (useNativeShare && navigator.canShare) {
       const shareData = {
         files: [
-          new File([blob], "katla.jpg", {
+          new File([blob], imageName, {
             type: "image/jpeg",
             lastModified: new Date().getTime(),
           }),
@@ -228,7 +229,7 @@ export default function StatsModal(props: Props) {
       const a = document.createElement("a");
       a.style.display = "none";
       a.href = url;
-      a.download = "katla.jpg";
+      a.download = imageName;
       document.body.appendChild(a);
       a.click();
       window.URL.revokeObjectURL(url);


### PR DESCRIPTION
Minor actually 🙈.

> Anyway, I'm not familiar with Javascript or any front-end web basically, so if this changes is not suitable, is okay to close this mas @pveyes 🙏

The idea is, I think it's good if the image downloaded is having game number on it's file, so user can always download their result's image without needing to "rename" it (since older and newer result of downloaded image will have the same name).